### PR TITLE
Fix GHA workflow to build and deploy Docker image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -10,7 +10,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  # formbio/laava
 
 jobs:
   docker:
@@ -31,6 +30,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
+        id: build-and-push
         uses: docker/build-push-action@v6
         with:
           file: laava.dockerfile
@@ -39,6 +39,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}:latest
+          subject-digest: ${{ steps.build-and-push.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
Previously the attestation step failed because it (a) didn't specify the Docker image tag, i.e. `:latest`, and (b) didn't reference the newly built container image's digest correctly. This PR fixes both issues.