### PR TITLE
Fixes for self-complementary AAV and workflow configuration

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -120,7 +120,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
-          trivy-options: '--timeout 45m'
+          timeout: '45m'
       
       # Upload Trivy scan results to GitHub Security tab
       - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -120,6 +120,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
+          trivy-options: '--timeout 45m'
       
       # Upload Trivy scan results to GitHub Security tab
       - name: Upload Trivy scan results to GitHub Security tab

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,6 +45,8 @@ params {
   container_repo = 'ghcr.io/formbio'
   // use ':dev' for local testing, ':latest' for cloud
   container_version = ':latest'
+
+  default_machine_type='e2-highmem-8'
 }
 
 process {
@@ -58,7 +60,7 @@ process {
   maxForks = 50
   cache = 'lenient'
   // Only has effect on cloud
-  machineType = 'e2-highmem-8'
+  machineType = params.default_machine_type
   disk = '500 GB'
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -46,12 +46,14 @@ params {
   // use ':dev' for local testing, ':latest' for cloud
   container_version = ':latest'
 
-  default_machine_type='e2-highmem-8'
+  cpus = 8
+  memory = '32 GB'
 }
 
 process {
   container = "${params.container_repo}/laava${params.container_version}"
-  cpus = 4
+  cpus = params.cpus
+  memory = params.memory
   //shell = ['/bin/bash', '-euo', 'pipefail']
 
   executor = 'google-batch'
@@ -60,7 +62,6 @@ process {
   maxForks = 50
   cache = 'lenient'
   // Only has effect on cloud
-  machineType = params.default_machine_type
   disk = '500 GB'
 }
 

--- a/src/summarize_alignment.py
+++ b/src/summarize_alignment.py
@@ -758,12 +758,15 @@ def run_processing_parallel(
 
     pool = []
     for i in range(num_chunks):
-        starting_readname = readname_list[i * chunk_size]
-        ending_readname = (
-            None
-            if (i + 1) * chunk_size >= total_num_reads
-            else readname_list[(i + 1) * chunk_size]
-        )
+        start_index = i * chunk_size
+        end_index = min((i + 1) * chunk_size, total_num_reads)
+
+        if start_index >= total_num_reads:
+            break  # Prevent out-of-range access
+
+        starting_readname = readname_list[start_index]
+        ending_readname = None if end_index >= total_num_reads else readname_list[end_index]
+
         p = Process(
             target=process_alignment_bam,
             args=(

--- a/src/summarize_alignment.py
+++ b/src/summarize_alignment.py
@@ -692,13 +692,15 @@ def process_alignment_records_for_a_read(
 
                 else:
                     # Additional not-really-scAAV subtypes
-                    read_type = "other-vector"
+                    # read_type = "other-vector"
                     assert supp_orientation is None, f"Unrecognized {supp_orientation=}"
                     if read_target_overlap == (
                         "right-partial" if is_mitr_left else "left-partial"
-                    ):
+                    ):  
+                        read_type = "scAAV"
                         read_subtype = "itr-partial"
                     else:
+                        read_type = "other-vector"
                         read_subtype = "unclassified"
 
             else:

--- a/src/summarize_alignment.py
+++ b/src/summarize_alignment.py
@@ -699,6 +699,7 @@ def process_alignment_records_for_a_read(
                     ):  
                         read_type = "scAAV"
                         read_subtype = "itr-partial"
+                        logging.debug("%s %s", read_type,read_subtype)
                     else:
                         read_type = "other-vector"
                         read_subtype = "unclassified"


### PR DESCRIPTION
## Summary
- Fixed sc-AAV itr-partial type classification to properly identify and classify itr-partial reads
- Fixed Azenta out of range error in sequence processing
- Added configuration parameters to customize machine type, CPU count, and memory allocation
- Default settings now configurable: 'e2-highmem-8', 8 CPUs, and 64GB memory

## Test plan
- Verify correct classification of sc-AAV itr-partial reads using test samples
- Confirm Azenta samples process without range errors
- Test custom resource configurations to ensure they override defaults correctly

Tested with different CPU count, it runs succesfully if you want to validate the generated report/data
[--cpus=8(default) ](https://app.formbio.com/organizations/form-bio-solutions/projects/laava-validation/workflow-runs/702003b9-918d-4dfa-9ed4-4ce46704d519/)
[--cpus=7 ](https://app.formbio.com/organizations/form-bio-solutions/projects/laava-validation/workflow-runs/1d5c7306-495b-41a6-a279-e355272a015f/?panel=metadata&previousPageParams=%7B%22orgId%22%3A%22form-bio-solutions%22%2C%22pid%22%3A%22laava-validation%22%2C%22panel%22%3A%22%22%2C%22status%22%3A%22%22%2C%22users%22%3A%22%22%2C%22selectedFile%22%3A%22%22%2C%22supportFile%22%3A%22%22%7D&selectedFile=pipeline-outputs%2Fformbio%2Flaava%2F2025-04-02T23_16_34Z_1d5c7306-495b-41a6-a279-e355272a015f%2Fnextflow%2Freport.html&supportFile=&tab=Logs) 
[--cpus=48 ](https://app.formbio.com/organizations/form-bio-solutions/projects/laava-validation/workflow-runs/f7e7938f-2334-4472-b96a-5df71bfec976/?panel=metadata&previousPageParams=%7B%22orgId%22%3A%22form-bio-solutions%22%2C%22pid%22%3A%22laava-validation%22%2C%22panel%22%3A%22%22%2C%22status%22%3A%22%22%2C%22users%22%3A%22%22%2C%22selectedFile%22%3A%22%22%2C%22supportFile%22%3A%22%22%7D&selectedFile=pipeline-outputs%2Fformbio%2Flaava%2F2025-04-02T23_16_42Z_f7e7938f-2334-4472-b96a-5df71bfec976%2Fnextflow%2Freport.html&supportFile=&tab=Logs&selectedTrace=7b%2Fca83e4)


## Test commands

NOTE:   To reference a container version in a pull-request or branch you can use the following
https://github.com/formbio/laava/pkgs/container/laava/388068909?tag=pr-94
```
--container_version=pr-94
```

You can also reference the branch name itself with `/` converted to `-` e.g.
https://github.com/formbio/laava/pkgs/container/laava/388068909?tag=alpha-sc-fixes
```
--container_version=alpha-sc-fixes
```


```
formbio workflow run \
--run-name 'xam-laava-4.0_CPU_48' \
--org form-bio-solutions \
--project laava-validation \
--repo formbio/laava \
--workflow formbio/laava \
--version alpha/sc-fixes  \
--execution-engine nextflow \
--github true \
-- \
--cpus=48 \
--container_version=pr-94 \
--flipflop_name='AAV2' \
--helper_name='pHelper' \
--host_fa='formbio://form-bio-solutions/laava-validation/reference/hs1.chm13.fa' \
--itr_label_1='itr-l' \
--itr_label_2='itr-r' \
--lambda_name='Lambda' \
--max_allowed_missing_flanking=100 \
--max_allowed_outside_vector=100 \
--min_supp_joint_coverage=0.8 \
--packaging_fa='formbio://form-bio-solutions/laava-validation/PacBio-example-AAV/2021-scAAV-CBA-eGFP/package.fa' \
--repcap_name='pRep2Cap9' \
--sample_display_name='xam' \
--sample_unique_id='demux.xam' \
--seq_reads_file='formbio://form-bio-solutions/laava-validation/PacBio-example-AAV/2022-ssAAV-pAV-CMF-GFP/0-reads/xam.bam' \
--target_gap_threshold=200 \
--ui_source_type='file_source' \
--vector_bed='formbio://form-bio-solutions/laava-validation/PacBio-example-AAV/2022-ssAAV-pAV-CMF-GFP/pAV-CMV-GFP.bed' \
--vector_fa='formbio://form-bio-solutions/laava-validation/PacBio-example-AAV/2022-ssAAV-pAV-CMF-GFP/pAV-CMV-GFP.fasta' \
--vector_type='ss'
```